### PR TITLE
refac: Update events to include order or payment id

### DIFF
--- a/apps/order/src/main/java/com/github/thorlauridsen/service/OrderOutboxService.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/service/OrderOutboxService.java
@@ -8,6 +8,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 /**
  * Service class for the order outbox.
  * This class is responsible for preparing events to be saved to the outbox table.
@@ -41,6 +43,7 @@ public class OrderOutboxService {
             return;
         }
         var event = new OrderCreatedEvent(
+                UUID.randomUUID(),
                 order.id(),
                 order.product(),
                 order.amount()

--- a/apps/order/src/test/java/com/github/thorlauridsen/OrderControllerTest.java
+++ b/apps/order/src/test/java/com/github/thorlauridsen/OrderControllerTest.java
@@ -58,6 +58,7 @@ public class OrderControllerTest extends BaseMockMvc {
         var created = createAndAssertOrder();
         var event = new PaymentCompletedEvent(
                 UUID.randomUUID(),
+                UUID.randomUUID(),
                 created.id(),
                 created.amount()
         );
@@ -69,6 +70,7 @@ public class OrderControllerTest extends BaseMockMvc {
     public void createOrder_PaymentFailed() throws Exception {
         var created = createAndAssertOrder();
         var event = new PaymentFailedEvent(
+                UUID.randomUUID(),
                 UUID.randomUUID(),
                 created.id()
         );

--- a/apps/order/src/test/java/com/github/thorlauridsen/OrderServiceTest.java
+++ b/apps/order/src/test/java/com/github/thorlauridsen/OrderServiceTest.java
@@ -44,6 +44,7 @@ public class OrderServiceTest {
         var created = createAndAssertOrder();
         var event = new PaymentCompletedEvent(
                 UUID.randomUUID(),
+                UUID.randomUUID(),
                 created.id(),
                 created.amount()
         );
@@ -55,6 +56,7 @@ public class OrderServiceTest {
     public void createOrder_PaymentFailed() {
         var created = createAndAssertOrder();
         var event = new PaymentFailedEvent(
+                UUID.randomUUID(),
                 UUID.randomUUID(),
                 created.id()
         );

--- a/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentOutboxService.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentOutboxService.java
@@ -6,6 +6,8 @@ import com.github.thorlauridsen.model.Payment;
 import com.github.thorlauridsen.outbox.OutboxRepoFacade;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 /**
  * Service class for the payment outbox.
  * This class is responsible for preparing events to be saved to the outbox table.
@@ -37,6 +39,7 @@ public class PaymentOutboxService {
         switch (payment.status()) {
             case COMPLETED -> {
                 var event = new PaymentCompletedEvent(
+                        UUID.randomUUID(),
                         payment.id(),
                         payment.orderId(),
                         payment.amount()
@@ -45,6 +48,7 @@ public class PaymentOutboxService {
             }
             case FAILED -> {
                 var event = new PaymentFailedEvent(
+                        UUID.randomUUID(),
                         payment.id(),
                         payment.orderId()
                 );

--- a/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentService.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentService.java
@@ -53,7 +53,7 @@ public class PaymentService {
             status = PaymentStatus.FAILED;
         }
         var payment = new PaymentCreate(
-                event.getId(),
+                event.getOrderId(),
                 status,
                 event.getAmount()
         );

--- a/apps/payment/src/test/java/com/github/thorlauridsen/PaymentServiceTest.java
+++ b/apps/payment/src/test/java/com/github/thorlauridsen/PaymentServiceTest.java
@@ -37,6 +37,7 @@ public class PaymentServiceTest {
     public void processOrderCreated() {
         var event = new OrderCreatedEvent(
                 UUID.randomUUID(),
+                UUID.randomUUID(),
                 "Computer",
                 199.0
         );

--- a/modules/event/src/main/java/com/github/thorlauridsen/event/OrderCreatedEvent.java
+++ b/modules/event/src/main/java/com/github/thorlauridsen/event/OrderCreatedEvent.java
@@ -10,18 +10,25 @@ import java.util.UUID;
  */
 public class OrderCreatedEvent extends BaseEvent {
 
+    private final UUID orderId;
     private final String product;
     private final double amount;
 
     @JsonCreator
     public OrderCreatedEvent(
             @JsonProperty("id") UUID id,
+            @JsonProperty("orderId") UUID orderId,
             @JsonProperty("product") String product,
             @JsonProperty("amount") double amount
     ) {
         super(id, EventType.ORDER_CREATED);
+        this.orderId = orderId;
         this.product = product;
         this.amount = amount;
+    }
+
+    public UUID getOrderId() {
+        return orderId;
     }
 
     public String getProduct() {

--- a/modules/event/src/main/java/com/github/thorlauridsen/event/PaymentCompletedEvent.java
+++ b/modules/event/src/main/java/com/github/thorlauridsen/event/PaymentCompletedEvent.java
@@ -10,18 +10,25 @@ import java.util.UUID;
  */
 public class PaymentCompletedEvent extends BaseEvent {
 
+    private final UUID paymentId;
     private final UUID orderId;
     private final double amount;
 
     @JsonCreator
     public PaymentCompletedEvent(
             @JsonProperty("id") UUID id,
+            @JsonProperty("paymentId") UUID paymentId,
             @JsonProperty("orderId") UUID orderId,
             @JsonProperty("amount") double amount
     ) {
         super(id, EventType.PAYMENT_COMPLETED);
+        this.paymentId = paymentId;
         this.orderId = orderId;
         this.amount = amount;
+    }
+
+    public UUID getPaymentId() {
+        return paymentId;
     }
 
     public UUID getOrderId() {

--- a/modules/event/src/main/java/com/github/thorlauridsen/event/PaymentFailedEvent.java
+++ b/modules/event/src/main/java/com/github/thorlauridsen/event/PaymentFailedEvent.java
@@ -10,15 +10,22 @@ import java.util.UUID;
  */
 public class PaymentFailedEvent extends BaseEvent {
 
+    private final UUID paymentId;
     private final UUID orderId;
 
     @JsonCreator
     public PaymentFailedEvent(
             @JsonProperty("id") UUID id,
+            @JsonProperty("paymentId") UUID paymentId,
             @JsonProperty("orderId") UUID orderId
     ) {
         super(id, EventType.PAYMENT_FAILED);
+        this.paymentId = paymentId;
         this.orderId = orderId;
+    }
+
+    public UUID getPaymentId() {
+        return paymentId;
     }
 
     public UUID getOrderId() {


### PR DESCRIPTION
- Add `orderId` to `OrderCreatedEvent`.
- Add `paymentId` to `PaymentCompletedEvent`.
- Add `paymentId` to `PaymentFailedEvent`.

This makes a clear distinction between the object id and the event id. We can then use the event ids for deduplication.