### PR TITLE
refac: Implement deduplication for PaymentService

### DIFF
--- a/apps/payment/build.gradle.kts
+++ b/apps/payment/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
 	// The payment subproject needs access to the following subprojects
 	implementation(projects.consumer)
+	implementation(projects.deduplication)
 	implementation(projects.event)
 	implementation(projects.jackson)
 	implementation(projects.model)

--- a/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentService.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/service/PaymentService.java
@@ -1,9 +1,13 @@
 package com.github.thorlauridsen.service;
 
+import com.github.thorlauridsen.deduplication.ProcessedEventEntity;
+import com.github.thorlauridsen.deduplication.ProcessedEventRepo;
 import com.github.thorlauridsen.enumeration.PaymentStatus;
 import com.github.thorlauridsen.event.OrderCreatedEvent;
 import com.github.thorlauridsen.model.PaymentCreate;
 import com.github.thorlauridsen.persistence.PaymentRepoFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -21,21 +25,27 @@ import java.util.Random;
 @Service
 public class PaymentService {
 
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     private final PaymentOutboxService outboxService;
     private final PaymentRepoFacade paymentRepo;
+    private final ProcessedEventRepo processedEventRepo;
 
     /**
      * Constructor for PaymentService.
      *
-     * @param outboxService {@link PaymentOutboxService} for preparing outbox events.
-     * @param paymentRepo   {@link PaymentRepoFacade} for interacting with the payment table.
+     * @param outboxService      {@link PaymentOutboxService} for preparing outbox events.
+     * @param paymentRepo        {@link PaymentRepoFacade} for interacting with the payment table.
+     * @param processedEventRepo {@link ProcessedEventRepo} for checking if an event has already been processed.
      */
     public PaymentService(
             PaymentOutboxService outboxService,
-            PaymentRepoFacade paymentRepo
+            PaymentRepoFacade paymentRepo,
+            ProcessedEventRepo processedEventRepo
     ) {
         this.outboxService = outboxService;
         this.paymentRepo = paymentRepo;
+        this.processedEventRepo = processedEventRepo;
     }
 
     /**
@@ -47,6 +57,10 @@ public class PaymentService {
      * @param event {@link OrderCreatedEvent}.
      */
     public void processOrderCreated(OrderCreatedEvent event) {
+        if (processedEventRepo.existsById(event.getId())) {
+            logger.warn("Event already processed with id: {}", event.getId());
+            return;
+        }
         var random = new Random().nextBoolean();
         var status = PaymentStatus.COMPLETED;
         if (random) {
@@ -57,7 +71,10 @@ public class PaymentService {
                 status,
                 event.getAmount()
         );
+        var processedEvent = new ProcessedEventEntity(event.getId());
+
         var saved = paymentRepo.create(payment);
+        processedEventRepo.save(processedEvent);
         outboxService.prepare(saved);
     }
 }

--- a/apps/payment/src/main/resources/db/changelog/patch/0003-create-processed-event-table.yaml
+++ b/apps/payment/src/main/resources/db/changelog/patch/0003-create-processed-event-table.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-processed-event-table
+      author: thorlauridsen
+      changes:
+        - createTable:
+            tableName: processed_event
+            columns:
+              - column:
+                  name: event_id
+                  type: UUID
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: processed_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false

--- a/apps/payment/src/test/java/com/github/thorlauridsen/PaymentServiceTest.java
+++ b/apps/payment/src/test/java/com/github/thorlauridsen/PaymentServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.thorlauridsen;
 
+import com.github.thorlauridsen.deduplication.ProcessedEventRepo;
 import com.github.thorlauridsen.event.OrderCreatedEvent;
 import com.github.thorlauridsen.outbox.OutboxRepo;
 import com.github.thorlauridsen.persistence.PaymentRepo;
@@ -17,20 +18,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PaymentServiceTest {
 
     @Autowired
-    private PaymentService paymentService;
+    private OutboxRepo outboxRepo;
 
     @Autowired
     private PaymentRepo paymentRepo;
 
     @Autowired
-    private OutboxRepo outboxRepo;
+    private PaymentService paymentService;
+
+    @Autowired
+    private ProcessedEventRepo processedEventRepo;
 
     @BeforeEach
     public void setup() {
-        paymentRepo.deleteAll();
         outboxRepo.deleteAll();
-        assertEquals(0, paymentRepo.count());
+        paymentRepo.deleteAll();
+        processedEventRepo.deleteAll();
         assertEquals(0, outboxRepo.count());
+        assertEquals(0, paymentRepo.count());
+        assertEquals(0, processedEventRepo.count());
     }
 
     @Test
@@ -42,7 +48,25 @@ public class PaymentServiceTest {
                 199.0
         );
         paymentService.processOrderCreated(event);
-        assertEquals(1, paymentRepo.count());
+
         assertEquals(1, outboxRepo.count());
+        assertEquals(1, paymentRepo.count());
+        assertEquals(1, processedEventRepo.count());
+    }
+
+    @Test
+    public void processOrderCreated_deduplicationWorks() {
+        var event = new OrderCreatedEvent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "Computer",
+                199.0
+        );
+        paymentService.processOrderCreated(event);
+        paymentService.processOrderCreated(event);
+
+        assertEquals(1, outboxRepo.count());
+        assertEquals(1, paymentRepo.count());
+        assertEquals(1, processedEventRepo.count());
     }
 }

--- a/modules/deduplication/build.gradle.kts
+++ b/modules/deduplication/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+import org.springframework.boot.gradle.tasks.run.BootRun
+
+plugins {
+	alias(local.plugins.springboot)
+	alias(local.plugins.spring.dependencies)
+}
+
+dependencies {
+	// The outbox subproject needs access to the following subprojects
+	implementation(projects.event)
+
+	// Spring Boot dependencies
+	implementation(local.springboot.starter)
+	implementation(local.springboot.starter.jpa)
+
+	// Jackson datatype JSR310 dependency for serializing Java 8 Date/Time API
+	implementation(local.jackson.datatype.jsr310)
+}
+
+// Disabling bootJar and bootRun is necessary for a subproject/module
+// that uses the Spring Boot plugin but is not supposed to be executable.
+tasks.named<BootJar>("bootJar") {
+	enabled = false
+}
+tasks.named<BootRun>("bootRun") {
+	enabled = false
+}

--- a/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/ProcessedEventEntity.java
+++ b/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/ProcessedEventEntity.java
@@ -1,0 +1,37 @@
+package com.github.thorlauridsen.deduplication;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "processed_event")
+public class ProcessedEventEntity {
+
+    @Id
+    private UUID eventId;
+
+    private OffsetDateTime processedAt;
+
+    /**
+     * Empty default constructor required by JPA.
+     */
+    public ProcessedEventEntity() {
+    }
+
+    public ProcessedEventEntity(UUID eventId) {
+        this.eventId = eventId;
+        this.processedAt = OffsetDateTime.now();
+    }
+
+    public UUID getEventId() {
+        return eventId;
+    }
+
+    public OffsetDateTime getProcessedAt() {
+        return processedAt;
+    }
+}

--- a/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/ProcessedEventRepo.java
+++ b/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/ProcessedEventRepo.java
@@ -1,0 +1,8 @@
+package com.github.thorlauridsen.deduplication;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProcessedEventRepo extends JpaRepository<ProcessedEventEntity, UUID> {
+}


### PR DESCRIPTION
The `processOrderCreated()` method in `PaymentService` is just for demonstration purposes and will randomly select whether to complete or fail the payment. However, this does mean that the method is not idempotent and this is a great chance to implement deduplication. 

- Add new subproject named `deduplication`:
  - Add `ProcessedEventEntity`.
  - Add `ProcessedEventRepo`.
- Add Liquibase yaml changelog for new `processed_event` table.
- Update `PaymentService` to check whether an event has already been processed. If not, it will be saved as processed.
- Update `PaymentServiceTest` to verify that deduplication works. Multiple events with the same event id will not add multiple payments.