### PR TITLE
refac: Add DeduplicationService for all processed events

### DIFF
--- a/apps/order/build.gradle.kts
+++ b/apps/order/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
 	// The order subproject needs access to the following subprojects
 	implementation(projects.consumer)
+	implementation(projects.deduplication)
 	implementation(projects.event)
 	implementation(projects.jackson)
 	implementation(projects.model)

--- a/apps/order/src/main/java/com/github/thorlauridsen/service/OrderService.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/service/OrderService.java
@@ -1,16 +1,16 @@
 package com.github.thorlauridsen.service;
 
+import com.github.thorlauridsen.deduplication.DeduplicationService;
 import com.github.thorlauridsen.enumeration.OrderStatus;
 import com.github.thorlauridsen.event.PaymentCompletedEvent;
 import com.github.thorlauridsen.event.PaymentFailedEvent;
 import com.github.thorlauridsen.model.Order;
 import com.github.thorlauridsen.model.OrderCreate;
 import com.github.thorlauridsen.persistence.OrderRepoFacade;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
 
 /**
  * Order service class.
@@ -26,21 +26,26 @@ import java.util.UUID;
 public class OrderService {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
-    private final OrderRepoFacade orderRepo;
+
+    private final DeduplicationService deduplicationService;
     private final OrderOutboxService outboxService;
+    private final OrderRepoFacade orderRepo;
 
     /**
      * Constructor for OrderService.
      *
-     * @param orderRepo     {@link OrderRepoFacade} for interacting with the order repository.
-     * @param outboxService {@link OrderOutboxService} for preparing outbox events.
+     * @param deduplicationService {@link DeduplicationService} for checking if an event has already been processed.
+     * @param orderRepo            {@link OrderRepoFacade} for interacting with the order repository.
+     * @param outboxService        {@link OrderOutboxService} for preparing outbox events.
      */
     public OrderService(
-            OrderRepoFacade orderRepo,
-            OrderOutboxService outboxService
+            DeduplicationService deduplicationService,
+            OrderOutboxService outboxService,
+            OrderRepoFacade orderRepo
     ) {
-        this.orderRepo = orderRepo;
+        this.deduplicationService = deduplicationService;
         this.outboxService = outboxService;
+        this.orderRepo = orderRepo;
     }
 
     /**
@@ -50,7 +55,12 @@ public class OrderService {
      * @param event {@link PaymentCompletedEvent}.
      */
     public void processPaymentCompleted(PaymentCompletedEvent event) {
+        if (deduplicationService.isDuplicate(event.getId())) {
+            logger.warn("Event already processed with id: {}", event.getId());
+            return;
+        }
         updateOrder(event.getOrderId(), OrderStatus.COMPLETED);
+        deduplicationService.recordEvent(event.getId());
     }
 
     /**
@@ -60,7 +70,12 @@ public class OrderService {
      * @param event {@link PaymentFailedEvent}.
      */
     public void processPaymentFailed(PaymentFailedEvent event) {
+        if (deduplicationService.isDuplicate(event.getId())) {
+            logger.warn("Event already processed with id: {}", event.getId());
+            return;
+        }
         updateOrder(event.getOrderId(), OrderStatus.CANCELLED);
+        deduplicationService.recordEvent(event.getId());
     }
 
     /**

--- a/apps/order/src/main/resources/db/changelog/patch/0003-create-processed-event-table.yaml
+++ b/apps/order/src/main/resources/db/changelog/patch/0003-create-processed-event-table.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-processed-event-table
+      author: thorlauridsen
+      changes:
+        - createTable:
+            tableName: processed_event
+            columns:
+              - column:
+                  name: event_id
+                  type: UUID
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: processed_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  defaultValueComputed: CURRENT_TIMESTAMP
+                  constraints:
+                    nullable: false

--- a/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/DeduplicationService.java
+++ b/modules/deduplication/src/main/java/com/github/thorlauridsen/deduplication/DeduplicationService.java
@@ -1,0 +1,43 @@
+package com.github.thorlauridsen.deduplication;
+
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for deduplicating events.
+ * This service is used to check if an event is a duplicate and to record events as processed.
+ */
+@Service
+public class DeduplicationService {
+
+    private final ProcessedEventRepo processedEventRepo;
+
+    /**
+     * Constructor for DeduplicationService.
+     *
+     * @param processedEventRepo {@link ProcessedEventRepo} for checking if an event has already been processed.
+     */
+    public DeduplicationService(ProcessedEventRepo processedEventRepo) {
+        this.processedEventRepo = processedEventRepo;
+    }
+
+    /**
+     * Check if an event is a duplicate.
+     *
+     * @param eventId UUID of the event to check.
+     * @return true if the event is a duplicate, false otherwise.
+     */
+    public boolean isDuplicate(UUID eventId) {
+        return processedEventRepo.existsById(eventId);
+    }
+
+    /**
+     * Record an event as processed.
+     *
+     * @param eventId UUID of the event to record.
+     */
+    public void recordEvent(UUID eventId) {
+        var processedEvent = new ProcessedEventEntity(eventId);
+        processedEventRepo.save(processedEvent);
+    }
+}


### PR DESCRIPTION
Add `DeduplicationService` which allows us to easily determine if an event has already been processed and record it as processed as well. Update `OrderService` to also use deduplication. The methods in `OrderService` are already idempotent because multiple consumed identical events would simply set the order status to what it has already been set to. However, I have added deduplication for this service as well to get into the habit of using deduplication. This is a good showcase of how you can implement deduplication in a project.