### PR TITLE
feat: Add Docker and docker-compose.yml

### DIFF
--- a/apps/order/src/main/resources/application.yml
+++ b/apps/order/src/main/resources/application.yml
@@ -9,9 +9,9 @@ spring:
       region:
         static: us-east-1
       sns:
-        endpoint: http://localhost:4566
+        endpoint: ${SPRING_CLOUD_AWS_SNS_ENDPOINT:http://localhost:4566}
       sqs:
-        endpoint: http://localhost:4566
+        endpoint: ${SPRING_CLOUD_AWS_SQS_ENDPOINT:http://localhost:4566}
   application:
     name: sample
 springdoc:

--- a/apps/payment/src/main/resources/application.yml
+++ b/apps/payment/src/main/resources/application.yml
@@ -9,9 +9,9 @@ spring:
       region:
         static: us-east-1
       sns:
-        endpoint: http://localhost:4566
+        endpoint: ${SPRING_CLOUD_AWS_SNS_ENDPOINT:http://localhost:4566}
       sqs:
-        endpoint: http://localhost:4566
+        endpoint: ${SPRING_CLOUD_AWS_SQS_ENDPOINT:http://localhost:4566}
   application:
     name: sample
 springdoc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  order:
+    build:
+      context: .
+      dockerfile: docker/order/Dockerfile
+    container_name: spring-boot-java-eda-order
+    image: spring-boot-java-eda-order:latest
+    environment:
+      SPRING_CLOUD_AWS_SNS_ENDPOINT: http://localstack:4566
+      SPRING_CLOUD_AWS_SQS_ENDPOINT: http://localstack:4566
+    depends_on:
+      - localstack
+    networks:
+      - localstack_network
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  payment:
+    build:
+      context: .
+      dockerfile: docker/payment/Dockerfile
+    container_name: spring-boot-java-eda-payment
+    image: spring-boot-java-eda-payment:latest
+    environment:
+      SPRING_CLOUD_AWS_SNS_ENDPOINT: http://localstack:4566
+      SPRING_CLOUD_AWS_SQS_ENDPOINT: http://localstack:4566
+    depends_on:
+      - localstack
+    networks:
+      - localstack_network
+    restart: unless-stopped
+
+  localstack:
+    image: localstack/localstack:4.2.0
+    container_name: localstack
+    ports:
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4510-4559:4510-4559"
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - LOCALSTACK_SERVICES=sqs,sns
+      - PERSISTENCE=/var/lib/localstack/data
+    volumes:
+      - "./docker/localstack/init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh"
+      - "localstack-data:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    command: chmod +x /etc/localstack/init/ready.d/init-localstack.sh
+    networks:
+      - localstack_network
+
+networks:
+  localstack_network:
+    driver: bridge
+
+volumes:
+  localstack-data:

--- a/docker/localstack/init-localstack.sh
+++ b/docker/localstack/init-localstack.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+awslocal sqs create-queue --queue-name order-created-queue
+awslocal sns create-topic --name order-created-topic
+awslocal sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/order-created-queue --attribute-name QueueArn
+awslocal sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:order-created-topic --protocol sqs --notification-endpoint arn:aws:sqs:us-east-1:000000000000:order-created-queue
+awslocal sqs create-queue --queue-name payment-completed-queue
+awslocal sns create-topic --name payment-completed-topic
+awslocal sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/payment-completed-queue --attribute-name QueueArn
+awslocal sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:payment-completed-topic --protocol sqs --notification-endpoint arn:aws:sqs:us-east-1:000000000000:payment-completed-queue
+awslocal sqs create-queue --queue-name payment-failed-queue
+awslocal sns create-topic --name payment-failed-topic
+awslocal sqs get-queue-attributes --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/payment-failed-queue --attribute-name QueueArn
+awslocal sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:payment-failed-topic --protocol sqs --notification-endpoint arn:aws:sqs:us-east-1:000000000000:payment-failed-queue
+awslocal sns list-subscriptions

--- a/docker/order/Dockerfile
+++ b/docker/order/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the order subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :order:clean :order:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21.0.6_7-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/order/build/libs/order.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]

--- a/docker/payment/Dockerfile
+++ b/docker/payment/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the payment subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :payment:clean :payment:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21.0.6_7-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/payment/build/libs/payment.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- Update `application.yml` in both `order` and `payment` service to use environment variables `SPRING_CLOUD_AWS_SNS_ENDPOINT` and `SPRING_CLOUD_AWS_SQS_ENDPOINT`.
- Add `docker/order/Dockerfile` which will build a runnable docker image for the `order` subproject.
- Add `docker/payment/Dockerfile` which will build a runnable docker image for the `payment` subproject.
- Add `docker-compose.yml` which will run a LocalStack image and build the two Spring Boot instances from their Dockerfiles and run everything together. 

This allows you to run the entire project with the two microservices and LocalStack using:
```
docker compose up -d
```