### PR TITLE
feat: Add PostgreSQL in docker-compose.yml

### DIFF
--- a/apps/order/build.gradle.kts
+++ b/apps/order/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 	// H2 database dependency for in-memory database
 	runtimeOnly(local.h2database)
 
+	// PostgreSQL database driver
+	runtimeOnly(local.postgres)
+
 	// Liquibase core dependency for database migrations
 	runtimeOnly(local.liquibase.core)
 

--- a/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentCompletedConsumer.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentCompletedConsumer.java
@@ -45,7 +45,7 @@ public class PaymentCompletedConsumer extends EventConsumer<PaymentCompletedEven
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("arn:aws:sqs:us-east-1:000000000000:payment-completed-queue")
+    @SqsListener("payment-completed-queue")
     public void listen(String json) {
         super.listen(json);
     }

--- a/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentFailedConsumer.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentFailedConsumer.java
@@ -45,7 +45,7 @@ public class PaymentFailedConsumer extends EventConsumer<PaymentFailedEvent> {
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("arn:aws:sqs:us-east-1:000000000000:payment-failed-queue")
+    @SqsListener("payment-failed-queue")
     public void listen(String json) {
         super.listen(json);
     }
@@ -61,4 +61,3 @@ public class PaymentFailedConsumer extends EventConsumer<PaymentFailedEvent> {
         return PaymentFailedEvent.class;
     }
 }
-

--- a/apps/order/src/main/resources/application.yml
+++ b/apps/order/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
   cloud:
     aws:
       credentials:

--- a/apps/payment/build.gradle.kts
+++ b/apps/payment/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
 	// H2 database dependency for in-memory database
 	runtimeOnly(local.h2database)
 
+	// PostgreSQL database driver
+	runtimeOnly(local.postgres)
+
 	// Liquibase core dependency for database migrations
 	runtimeOnly(local.liquibase.core)
 

--- a/apps/payment/src/main/java/com/github/thorlauridsen/consumer/OrderCreatedConsumer.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/consumer/OrderCreatedConsumer.java
@@ -45,7 +45,7 @@ public class OrderCreatedConsumer extends EventConsumer<OrderCreatedEvent> {
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("arn:aws:sqs:us-east-1:000000000000:order-created-queue")
+    @SqsListener("order-created-queue")
     public void listen(String json) {
         super.listen(json);
     }

--- a/apps/payment/src/main/resources/application.yml
+++ b/apps/payment/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8081
 spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
   cloud:
     aws:
       credentials:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,30 @@
 services:
+  order-postgres:
+    image: postgres:17
+    container_name: order-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: order-db
+    ports:
+      - "5434:5432"
+    networks:
+      - localstack_network
+    restart: unless-stopped
+
+  payment-postgres:
+    image: postgres:17
+    container_name: payment-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: payment-db
+    ports:
+      - "5432:5432"
+    networks:
+      - localstack_network
+    restart: unless-stopped
+
   order:
     build:
       context: .
@@ -8,7 +34,11 @@ services:
     environment:
       SPRING_CLOUD_AWS_SNS_ENDPOINT: http://localstack:4566
       SPRING_CLOUD_AWS_SQS_ENDPOINT: http://localstack:4566
+      SPRING_DATASOURCE_URL: jdbc:postgresql://order-postgres:5432/order-db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
     depends_on:
+      - order-postgres
       - localstack
     networks:
       - localstack_network
@@ -25,7 +55,11 @@ services:
     environment:
       SPRING_CLOUD_AWS_SNS_ENDPOINT: http://localstack:4566
       SPRING_CLOUD_AWS_SQS_ENDPOINT: http://localstack:4566
+      SPRING_DATASOURCE_URL: jdbc:postgresql://payment-postgres:5432/payment-db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
     depends_on:
+      - payment-postgres
       - localstack
     networks:
       - localstack_network
@@ -43,7 +77,6 @@ services:
       - PERSISTENCE=/var/lib/localstack/data
     volumes:
       - "./docker/localstack/init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh"
-      - "localstack-data:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
     command: chmod +x /etc/localstack/init/ready.d/init-localstack.sh
     networks:
@@ -52,6 +85,3 @@ services:
 networks:
   localstack_network:
     driver: bridge
-
-volumes:
-  localstack-data:

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -4,6 +4,7 @@ h2database = "2.3.232"
 jackson = "2.18.3"
 junitPlatformLauncher = "1.11.4"
 liquibase = "4.31.1"
+postgres = "42.7.5"
 springboot = "3.4.4"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.5"
@@ -25,6 +26,9 @@ liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liqui
 
 # FasterXML Jackson libraries for JSON serialization
 jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
+
+# PostgreSQL for live database
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 
 # Spring Boot libraries
 springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }


### PR DESCRIPTION
- Add Gradle dependency PostgreSQL driver.
  - Add dependency to `build.gradle.kts` in both `order` and `payment` subprojects.
- Update SqsListener annotations to only use queue name instead of full ARN.
- Update `application.yml` in both `order` and `payment` subprojects to use environment variables for `spring.datasource`. This allows us to customize the datasource in `docker-compose.yml`.
- Update `docker-compose.yml` to include a PostgreSQL service for both `order` and `payment` services.

Now you can run the entire project with LocalStack, two microservices and postgres databases with a single command:
```
docker compose up -d
```