### PR TITLE
refac: Make it possible to configure AWS topic and queue ARN

### DIFF
--- a/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentCompletedConsumer.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentCompletedConsumer.java
@@ -45,7 +45,7 @@ public class PaymentCompletedConsumer extends EventConsumer<PaymentCompletedEven
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("payment-completed-queue")
+    @SqsListener("${app.queues.payment-completed}")
     public void listen(String json) {
         super.listen(json);
     }

--- a/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentFailedConsumer.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/consumer/PaymentFailedConsumer.java
@@ -45,7 +45,7 @@ public class PaymentFailedConsumer extends EventConsumer<PaymentFailedEvent> {
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("payment-failed-queue")
+    @SqsListener("${app.queues.payment-failed}")
     public void listen(String json) {
         super.listen(json);
     }

--- a/apps/order/src/main/java/com/github/thorlauridsen/producer/OrderCreatedProducer.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/producer/OrderCreatedProducer.java
@@ -2,6 +2,7 @@ package com.github.thorlauridsen.producer;
 
 import com.github.thorlauridsen.event.OrderCreatedEvent;
 import io.awspring.cloud.sns.core.SnsTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -15,8 +16,12 @@ public class OrderCreatedProducer extends EventProducer<OrderCreatedEvent> {
      * Constructor for OrderCreatedProducer.
      *
      * @param snsTemplate {@link SnsTemplate} to send the event to the SNS topic.
+     * @param topicArn    The SNS topic ARN to publish the event to.
      */
-    public OrderCreatedProducer(SnsTemplate snsTemplate) {
-        super(snsTemplate, "arn:aws:sns:us-east-1:000000000000:order-created-topic");
+    public OrderCreatedProducer(
+            SnsTemplate snsTemplate,
+            @Value("${app.topics.order-created}") String topicArn
+    ) {
+        super(snsTemplate, topicArn);
     }
 }

--- a/apps/order/src/main/resources/application.yml
+++ b/apps/order/src/main/resources/application.yml
@@ -24,3 +24,9 @@ springdoc:
   swagger-ui:
     enabled: true
     path: /
+app:
+  queues:
+    payment-completed: payment-completed-queue
+    payment-failed: payment-failed-queue
+  topics:
+    order-created: order-created-topic

--- a/apps/payment/src/main/java/com/github/thorlauridsen/consumer/OrderCreatedConsumer.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/consumer/OrderCreatedConsumer.java
@@ -45,7 +45,7 @@ public class OrderCreatedConsumer extends EventConsumer<OrderCreatedEvent> {
      * @param json The JSON message from the SQS queue as a String.
      */
     @Override
-    @SqsListener("order-created-queue")
+    @SqsListener("${app.queues.order-created}")
     public void listen(String json) {
         super.listen(json);
     }

--- a/apps/payment/src/main/java/com/github/thorlauridsen/producer/PaymentCompletedProducer.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/producer/PaymentCompletedProducer.java
@@ -2,6 +2,7 @@ package com.github.thorlauridsen.producer;
 
 import com.github.thorlauridsen.event.PaymentCompletedEvent;
 import io.awspring.cloud.sns.core.SnsTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -15,8 +16,12 @@ public class PaymentCompletedProducer extends EventProducer<PaymentCompletedEven
      * Constructor for PaymentCompletedProducer.
      *
      * @param snsTemplate {@link SnsTemplate} for publishing events.
+     * @param topicArn    The SNS topic ARN to publish the event to.
      */
-    public PaymentCompletedProducer(SnsTemplate snsTemplate) {
-        super(snsTemplate, "arn:aws:sns:us-east-1:000000000000:payment-completed-topic");
+    public PaymentCompletedProducer(
+            SnsTemplate snsTemplate,
+            @Value("${app.topics.payment-completed}") String topicArn
+    ) {
+        super(snsTemplate, topicArn);
     }
 }

--- a/apps/payment/src/main/java/com/github/thorlauridsen/producer/PaymentFailedProducer.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/producer/PaymentFailedProducer.java
@@ -2,6 +2,7 @@ package com.github.thorlauridsen.producer;
 
 import com.github.thorlauridsen.event.PaymentFailedEvent;
 import io.awspring.cloud.sns.core.SnsTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -15,8 +16,12 @@ public class PaymentFailedProducer extends EventProducer<PaymentFailedEvent> {
      * Constructor for PaymentFailedProducer.
      *
      * @param snsTemplate {@link SnsTemplate} to publish the event to the SNS topic.
+     * @param topicArn    The SNS topic ARN to publish the event to.
      */
-    public PaymentFailedProducer(SnsTemplate snsTemplate) {
-        super(snsTemplate, "arn:aws:sns:us-east-1:000000000000:payment-failed-topic");
+    public PaymentFailedProducer(
+            SnsTemplate snsTemplate,
+            @Value("${app.topics.payment-failed}") String topicArn
+    ) {
+        super(snsTemplate, topicArn);
     }
 }

--- a/apps/payment/src/main/resources/application.yml
+++ b/apps/payment/src/main/resources/application.yml
@@ -24,3 +24,9 @@ springdoc:
   swagger-ui:
     enabled: true
     path: /
+app:
+  queues:
+    order-created: order-created-queue
+  topics:
+    payment-completed: payment-completed-topic
+    payment-failed: payment-failed-topic


### PR DESCRIPTION
Update `@SqlListener` in consumer classes to look for queues in `application.yml` and update the producer classes to look for topics in `application.yml`. This makes it possible to easily configure the queues and topics if necessary.