### PR TITLE
refac: Add HTTP GET /payments/{orderId} for retrieving a payment

### DIFF
--- a/apps/payment/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
@@ -1,0 +1,8 @@
+package com.github.thorlauridsen.controller;
+
+/**
+ * This class contains the base endpoint constant for the payment controller.
+ */
+public class BaseEndpoint {
+    public static final String PAYMENT_BASE_ENDPOINT = "/payments";
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/controller/IPaymentController.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/controller/IPaymentController.java
@@ -1,0 +1,56 @@
+package com.github.thorlauridsen.controller;
+
+import com.github.thorlauridsen.dto.ErrorDto;
+import com.github.thorlauridsen.dto.PaymentDto;
+import com.github.thorlauridsen.exception.PaymentNotFoundException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static com.github.thorlauridsen.controller.BaseEndpoint.PAYMENT_BASE_ENDPOINT;
+
+/**
+ * Payment controller interface.
+ * This interface defines the endpoints for the payment controller.
+ * It also defines the operations which will be used in the OpenAPI documentation.
+ * The purpose with this interface is to separate the controller definition from the implementation.
+ */
+@Tag(name = "Payment Controller", description = "API for managing payments")
+@RequestMapping(PAYMENT_BASE_ENDPOINT)
+public interface IPaymentController {
+
+    /**
+     * Get payment by id.
+     * This method returns a payment given an order id.
+     *
+     * @param orderId UUID of the order related to the payment.
+     * @return {@link ResponseEntity} with {@link PaymentDto}.
+     * @throws PaymentNotFoundException if the payment is not found.
+     */
+    @GetMapping("/{orderId}")
+    @Operation(
+            summary = "Retrieve a payment",
+            description = "Retrieve a payment"
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Successfully retrieved payment"
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Payment not found with given order id",
+            content = @Content(schema = @Schema(implementation = ErrorDto.class))
+    )
+    ResponseEntity<PaymentDto> getByOrderId(
+            @Parameter(description = "UUID of the order related to the payment", required = true)
+            @PathVariable UUID orderId
+    ) throws PaymentNotFoundException;
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/controller/PaymentController.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/controller/PaymentController.java
@@ -1,0 +1,43 @@
+package com.github.thorlauridsen.controller;
+
+import com.github.thorlauridsen.dto.PaymentDto;
+import com.github.thorlauridsen.exception.PaymentNotFoundException;
+import com.github.thorlauridsen.service.PaymentService;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Payment controller class.
+ * This class implements the {@link IPaymentController} interface and
+ * overrides the methods defined in the interface with implementations.
+ * The controller is responsible for converting data transfer objects to models and vice versa.
+ */
+@RestController
+public class PaymentController implements IPaymentController {
+
+    private final PaymentService paymentService;
+
+    /**
+     * Constructor for PaymentController.
+     *
+     * @param paymentService {@link PaymentService}.
+     */
+    public PaymentController(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+
+    /**
+     * Get method for payment.
+     * This method will convert the model to a DTO and return it.
+     *
+     * @param orderId UUID of the order related to the payment.
+     * @return {@link ResponseEntity} with {@link PaymentDto}.
+     * @throws PaymentNotFoundException if the payment is not found.
+     */
+    @Override
+    public ResponseEntity<PaymentDto> getByOrderId(UUID orderId) throws PaymentNotFoundException {
+        var payment = paymentService.findByOrderId(orderId);
+        return ResponseEntity.ok(PaymentDto.fromModel(payment));
+    }
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/dto/PaymentDto.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/dto/PaymentDto.java
@@ -1,0 +1,55 @@
+package com.github.thorlauridsen.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.thorlauridsen.enumeration.PaymentStatus;
+import com.github.thorlauridsen.model.Payment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Data transfer object for a payment.
+ *
+ * @param id      UUID of the payment.
+ * @param orderId UUID of the related order.
+ * @param time    time payment was created in database.
+ * @param status  current payment status.
+ * @param amount  amount to be paid (or that has been paid if complete)
+ */
+@Schema(
+        description = "Data transfer object for a payment",
+        example = """
+                {
+                    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                    "orderId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                    "time": "2025-03-13T18:39:00Z",
+                    "status": "COMPLETED",
+                    "amount": 199.0
+                }
+                """
+)
+public record PaymentDto(
+        @JsonProperty("id") UUID id,
+        @JsonProperty("orderId") UUID orderId,
+        @JsonProperty("time") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssX") OffsetDateTime time,
+        @JsonProperty("status") PaymentStatus status,
+        @JsonProperty("amount") double amount
+) {
+
+    /**
+     * Static method to convert an {@link Payment} model to an {@link PaymentDto}.
+     *
+     * @param payment {@link Payment} to convert.
+     * @return {@link PaymentDto}.
+     */
+    public static PaymentDto fromModel(Payment payment) {
+        return new PaymentDto(
+                payment.id(),
+                payment.orderId(),
+                payment.time(),
+                payment.status(),
+                payment.amount()
+        );
+    }
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/exception/ControllerAdvisor.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/exception/ControllerAdvisor.java
@@ -21,9 +21,23 @@ public class ControllerAdvisor extends ResponseEntityExceptionHandler {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
+     * Handles all domain exceptions.
+     * If any {@link DomainException} is thrown, this method will
+     * catch it and return a response entity with an {@link ErrorDto}.
+     * The returned HTTP status code will be derived from the specific {@link DomainException}.
+     *
+     * @param exception The domain exception to handle.
+     * @return A response entity with an {@link ErrorDto}.
+     */
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ErrorDto> handleDomainException(DomainException exception) {
+        return error(exception, exception.getHttpStatus());
+    }
+
+    /**
      * Handles all exceptions.
      * If any exception is thrown, this method will catch it and return a response entity with an {@link ErrorDto}.
-     * Returns an HTTP 500 status code.
+     * Returns an HTTP 500 status code if no domain exception is thrown.
      *
      * @param exception The exception to handle.
      * @return A response entity with an {@link ErrorDto}.

--- a/apps/payment/src/main/java/com/github/thorlauridsen/exception/DomainException.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/exception/DomainException.java
@@ -1,0 +1,45 @@
+package com.github.thorlauridsen.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Abstract class representing a domain exception.
+ * Custom domain exceptions should extend this class.
+ */
+public abstract class DomainException extends Exception {
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    /**
+     * Constructor for a domain exception.
+     *
+     * @param message    The message of the exception.
+     * @param httpStatus The {@link HttpStatus} of the exception.
+     */
+    public DomainException(
+            String message,
+            HttpStatus httpStatus
+    ) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    /**
+     * Get the message of the exception.
+     *
+     * @return The message of the exception.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Get the {@link HttpStatus} of the exception.
+     *
+     * @return The {@link HttpStatus} of the exception.
+     */
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/exception/PaymentNotFoundException.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/exception/PaymentNotFoundException.java
@@ -1,0 +1,20 @@
+package com.github.thorlauridsen.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown when a payment is not found.
+ * Extends {@link DomainException}.
+ */
+public class PaymentNotFoundException extends DomainException {
+
+    /**
+     * Constructor for a payment not found exception.
+     * Sets the http status to {@link HttpStatus#NOT_FOUND}.
+     *
+     * @param message The message of the exception.
+     */
+    public PaymentNotFoundException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/apps/payment/src/main/java/com/github/thorlauridsen/persistence/PaymentRepo.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/persistence/PaymentRepo.java
@@ -1,9 +1,9 @@
 package com.github.thorlauridsen.persistence;
 
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.UUID;
 
 /**
  * Payment repository interface.
@@ -12,4 +12,12 @@ import java.util.UUID;
  */
 @Repository
 public interface PaymentRepo extends JpaRepository<PaymentEntity, UUID> {
+
+    /**
+     * Find a payment by order id.
+     *
+     * @param orderId UUID of the order.
+     * @return {@link Optional} of {@link PaymentEntity}.
+     */
+    Optional<PaymentEntity> findByOrderId(UUID orderId);
 }

--- a/apps/payment/src/main/java/com/github/thorlauridsen/persistence/PaymentRepoFacade.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/persistence/PaymentRepoFacade.java
@@ -2,6 +2,8 @@ package com.github.thorlauridsen.persistence;
 
 import com.github.thorlauridsen.model.Payment;
 import com.github.thorlauridsen.model.PaymentCreate;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -43,5 +45,16 @@ public class PaymentRepoFacade {
         );
         var saved = repo.save(entity);
         return saved.toModel();
+    }
+
+    /**
+     * Find a payment by order id.
+     *
+     * @param orderId UUID of the order related to the payment.
+     * @return {@link Optional} of {@link Payment}.
+     */
+    public Optional<Payment> findByOrderId(UUID orderId) {
+        var found = repo.findByOrderId(orderId);
+        return found.map(PaymentEntity::toModel);
     }
 }

--- a/apps/payment/src/test/java/com/github/thorlauridsen/BaseMockMvc.java
+++ b/apps/payment/src/test/java/com/github/thorlauridsen/BaseMockMvc.java
@@ -1,0 +1,54 @@
+package com.github.thorlauridsen;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+/**
+ * This is the BaseMockMvc class which allows you to send and test HTTP requests.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class BaseMockMvc {
+
+    private final MockMvc mockMvc;
+
+    @Autowired
+    public BaseMockMvc(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    /**
+     * Mock an HTTP POST request.
+     *
+     * @param jsonBody JSON body as a string.
+     * @param postUrl  The URL to send an HTTP POST request to.
+     * @return {@link MockHttpServletResponse} response.
+     */
+    public MockHttpServletResponse mockPost(String jsonBody, String postUrl) throws Exception {
+        return mockMvc.perform(
+                MockMvcRequestBuilders
+                        .post(postUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody)
+        ).andReturn().getResponse();
+    }
+
+    /**
+     * Mock an HTTP GET request.
+     *
+     * @param getUrl The URL to send an HTTP GET request to.
+     * @return {@link MockHttpServletResponse} response.
+     */
+    public MockHttpServletResponse mockGet(String getUrl) throws Exception {
+        return mockMvc.perform(
+                MockMvcRequestBuilders
+                        .get(getUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andReturn().getResponse();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       - localstack
     networks:
       - localstack_network
+    ports:
+      - "8081:8081"
     restart: unless-stopped
 
   localstack:


### PR DESCRIPTION
- Add `PaymentDto`.
- Add `IPaymentController` and `PaymentController` which includes new HTTP GET /payments/{orderId} for retrieving a payment given an order id.
- Add domain exception `PaymentNotFoundException`.
- Add `findByOrderId()` method in `PaymentService` to retrieve a payment given an order id.
- Add `PaymentControllerTest`.
- Update `PaymentServiceTest` to test `findByOrderId()` method.
- Update `docker-compose.yml` to expose 8081 for payment service.