### PR TITLE
build: Use Kotlin DSL accessors in build.gradle.kts files

### DIFF
--- a/apps/order/build.gradle.kts
+++ b/apps/order/build.gradle.kts
@@ -46,6 +46,6 @@ dependencies {
 	testRuntimeOnly(local.junit.platform.launcher)
 }
 
-tasks.withType<Test> {
+tasks.test {
 	useJUnitPlatform()
 }

--- a/apps/payment/build.gradle.kts
+++ b/apps/payment/build.gradle.kts
@@ -46,6 +46,6 @@ dependencies {
 	testRuntimeOnly(local.junit.platform.launcher)
 }
 
-tasks.withType<Test> {
+tasks.test {
 	useJUnitPlatform()
 }

--- a/modules/deduplication/build.gradle.kts
+++ b/modules/deduplication/build.gradle.kts
@@ -1,25 +1,22 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
-	alias(local.plugins.lombok)
-	alias(local.plugins.springboot)
-	alias(local.plugins.spring.dependencies)
+    alias(local.plugins.lombok)
+    alias(local.plugins.springboot)
+    alias(local.plugins.spring.dependencies)
 }
 
 dependencies {
-	// The outbox subproject needs access to the model subproject
-	implementation(projects.model)
+    // The outbox subproject needs access to the model subproject
+    implementation(projects.model)
 
-	// Spring Boot dependencies
-	implementation(local.springboot.starter.jpa)
+    // Spring Boot dependencies
+    implementation(local.springboot.starter.jpa)
 }
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
-	enabled = false
+tasks.bootJar {
+    enabled = false
 }
-tasks.named<BootRun>("bootRun") {
-	enabled = false
+tasks.bootRun {
+    enabled = false
 }

--- a/modules/event/build.gradle.kts
+++ b/modules/event/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
     alias(local.plugins.lombok)
     alias(local.plugins.springboot)
@@ -21,9 +18,9 @@ dependencies {
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
+tasks.bootJar {
     enabled = false
 }
-tasks.named<BootRun>("bootRun") {
+tasks.bootRun {
     enabled = false
 }

--- a/modules/exception/build.gradle.kts
+++ b/modules/exception/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
     alias(local.plugins.lombok)
     alias(local.plugins.springboot)
@@ -21,9 +18,9 @@ dependencies {
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
+tasks.bootJar {
     enabled = false
 }
-tasks.named<BootRun>("bootRun") {
+tasks.bootRun {
     enabled = false
 }

--- a/modules/jackson/build.gradle.kts
+++ b/modules/jackson/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
     alias(local.plugins.lombok)
     alias(local.plugins.springboot)
@@ -18,9 +15,9 @@ dependencies {
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
+tasks.bootJar {
     enabled = false
 }
-tasks.named<BootRun>("bootRun") {
+tasks.bootRun {
     enabled = false
 }

--- a/modules/outbox/build.gradle.kts
+++ b/modules/outbox/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
 	alias(local.plugins.lombok)
 	alias(local.plugins.springboot)
@@ -20,9 +17,9 @@ dependencies {
 
 // Disabling bootJar and bootRun is necessary for a subproject/module
 // that uses the Spring Boot plugin but is not supposed to be executable.
-tasks.named<BootJar>("bootJar") {
+tasks.bootJar {
 	enabled = false
 }
-tasks.named<BootRun>("bootRun") {
+tasks.bootRun {
 	enabled = false
 }


### PR DESCRIPTION
Take advantage of the features of Kotlin DSL by using accessors in `build.gradle.kts` files.