### PR TITLE
refac: Use Lombok UtilityClass annotation in BaseEndpoint

### DIFF
--- a/apps/order/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
+++ b/apps/order/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
@@ -1,8 +1,11 @@
 package com.github.thorlauridsen.controller;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * This class contains the base endpoint constant for the order controller.
  */
+@UtilityClass
 public class BaseEndpoint {
     public static final String ORDER_BASE_ENDPOINT = "/orders";
 }

--- a/apps/payment/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
+++ b/apps/payment/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
@@ -1,8 +1,11 @@
 package com.github.thorlauridsen.controller;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * This class contains the base endpoint constant for the payment controller.
  */
+@UtilityClass
 public class BaseEndpoint {
     public static final String PAYMENT_BASE_ENDPOINT = "/payments";
 }


### PR DESCRIPTION
Use Lombok UtilityClass annotation in BaseEndpoint because the class is an utility class with only a static constant.